### PR TITLE
Deprecate the GitBook plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Chart.js plugin for GitBook
+# Deprecated
 
-[![npm](https://img.shields.io/npm/v/gitbook-plugin-chartjs.svg?style=flat-square)](https://npmjs.com/package/gitbook-plugin-chartjs)
-
-## License
-
-gitbook-plugin-chartjs is available under the [MIT license](LICENSE.md).
+Chart.js has migrated from GitBook to Docusaurus


### PR DESCRIPTION
If we want to archive this we should merge or close the open PR. From the GitHub help docs:

> We recommend that you close all issues and pull requests, as well as update the README file and description, before you archive a repository

> When a repository is archived, its issues, pull requests, code, labels, milestones, projects, wiki, releases, commits, tags, branches, reactions, and comments become read-only. To make changes in an archived repository, you must unarchive the repository first.